### PR TITLE
Require Python >= 3.9

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
 
     steps:
     - uses: actions/checkout@v4

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     description = DESCRIPTION,
     long_description = long_description,
     long_description_content_type = "text/markdown",
-    python_requires = '>=3.8',
+    python_requires = '>=3.9',
     entry_points = {
         # see https://python-packaging.readthedocs.io/en/latest/command-line-scripts.html#the-console-scripts-entry-point
         'console_scripts': [


### PR DESCRIPTION
Remove support for Python 3.8 which is reaching end of life soon and is not supported by the latest Pytest version